### PR TITLE
Change README.md to fit new repo objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,35 @@ to take notes on that item.
 To start taking notes, you create a file inside `/reading` or `/viare/reading`. 
 The name of the file will be `{Author's Surname}{Year} - {Title}.tex`. If that file
 already exists, it must mean that someone already started taking notes. In such case,
-you should add your name as a subtitle at the end of the file, and start taking notes in there.
+you should add `\subsection{ {username} }` at the end of the file, and start taking
+notes in there.
 
 Example filenames:
 
 - `/reading/Kleinberg2005-Algorithm-design.tex`
 - `/viare/reading/Ilachinski2004-Artificial-war.tex`
 
+
+Example file content:
+
+```latex
+% ...
+
+\begin{document}
+% ...
+
+\section{quevangel}
+% {notes}
+
+\section{davidomarf}
+% {notes}
+```
+
 ---
 
-A note must be added to the book entry in `/to-read.md` or `/viare/to-read.md` indicating your name and the date you started reading it in format YYYY-MM-DD. For example:
+A note must be added to the book entry in `/to-read.md` or `/viare/to-read.md`
+indicating your name and the date you started reading it in format YYYY-M   M-DD.
+For example:
 
 `- {Book entry} | David, 2019-02-20`
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This is the place in where we share the list of references we use to keep developing
 [ViaRE](https://github.com/daque-dev/viare).
 
+This includes both:
+1. books that will be directly used as reference for new integrations into ViaRE, and
+1. books that help Daque members become better developers (or persons).
+
 ## Content
 - [The proccess](#the-proccess) (how to add more references to this repo)
 
@@ -10,24 +14,73 @@ This is the place in where we share the list of references we use to keep develo
 
 Every reference we find must go through this proccess:
 
-- **The Finding**: We find a book, website, article, magazine, etc. that we consider
+### The Finding
+    
+We find a book, website, article, magazine, etc. that we consider
 may be useful to keep generating ideas, getting context, or keeping us interested.
+
+If the book could be used to generate ideas for ViaRE, it will be added to 
+`/viare/to-read.md`. 
+Otherwise, it will be added to `/to-read.md`
+
 When we skim the table of contents or something similar, we should take note of what
-the book could give to ViaRe, and then add it to `FINDING.md`.
+the book could provide us.
 
-- **Note-taking**: When any member or contributor of [Daque](https://github.com/orgs/daque-dev/people)
-starts to read an item inside `finding list`, they must start to take notes on that
-item. If a file of notes on that item already exists, it should add the notes under
-a subtitle with their name.
+### Note-taking
 
-- **Referencing notes**: Every file with notes must be referenced from this file, under
+When any member or contributor of [Daque](https://github.com/orgs/daque-dev/people)
+starts to read an item inside `/to-read.md` or `/viare/to-read.md`, they must start
+to take notes on that item. 
+
+To start taking notes, you create a file inside `/reading` or `/viare/reading`. 
+The name of the file will be `{Author's Surname}{Year} - {Title}.tex`. If that file
+already exists, it must mean that someone already started taking notes. In such case,
+you should add your name as a subtitle at the end of the file, and start taking notes in there.
+
+Example filenames:
+
+- `/reading/Kleinberg2005-Algorithm-design.tex`
+- `/viare/reading/Ilachinski2004-Artificial-war.tex`
+
+---
+
+A note must be added to the book entry in `/to-read.md` or `/viare/to-read.md` indicating your name and the date you started reading it in format YYYY-MM-DD. For example:
+
+`- {Book entry} | David, 2019-02-20`
+
+
+### Finished books
+
+When any book is finished by any member, they must move their notes to `/notes` or 
+`/viare/notes`, and remove them from `/reading` or `/viare/reading`. 
+
+The last member to finish the book, should remove the book entry entirely from `reading`.
+
+### Referencing notes
+
+Every file inside `/notes`  or `/viare/notes` must be referenced from this file, under
 the category (or categories) it fits better in. If no category seems appropiate, it
 should be discussed in a new issue. A brief paragraph must accompany the entry, and
 must describe the most general contribution to this knowledge-base.
 
-- **Abstraction and Description**: Trying to abstract the new acquired knowledge and
-describe it mathematically, getting it ready to the last step.
+## Notes
 
-- **Implementation**: Reflected in a new repository, meant to explore the idea and do
-a lot of experiments, updating our mathematical description until we feel is ready to
-be included in ViaRE's main repository.
+### /
+
+#### Development
+
+- **{Book title with link to entry in `/notes`}**: {Brief description of the content}
+
+#### Mathematical Thinking
+
+- **{Book title with link to entry in `/notes`}**: {Brief description of the content}
+
+### /viare
+
+#### Geography
+
+- **{Book title with link to entry in `/viare/notes`}**: {Brief description of the content}
+
+#### Evolution
+
+- **{Book title with link to entry in `/viare/notes`}**: {Brief description of the content}


### PR DESCRIPTION
As discussed via private chat over the last days, `ref` should
serve the purpose of containing a book list that Daque members
find interesting to
a) develop viare, or
b) become better developers

The changes in this commit reflect this new objective by modifying
the proccess of note taking. Books are now categorized as general or
viare-specific.